### PR TITLE
gulp decompress: deal with failures

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,8 +55,13 @@ const download = exports.download = function download(done){
 };
 
 const decompress = exports.decompress = function decompress(done) {
-	exec("lunzip data/ep_meps_current.json.lz -f");
-	done();
+	exec("lunzip data/ep_meps_current.json.lz -f", function(err, stdout, stderr) {
+		if (err) {
+			console.log("Error on decompress: " + stderr);
+		} else {
+			done();
+		}
+	});
 };
 
 const mepid = exports.mepid = function mepid(done) {


### PR DESCRIPTION
In a machine without lunzip installed, gulp would fail on transform,
becuase it assumes that decompress ran successfully, and that wasn't
the case, only decompress wasn't validating any errors.

This patch changes gulp decompress to validate that the exec'd command
ends successfully, and prints the error message in case it didn't.